### PR TITLE
Fix #19

### DIFF
--- a/data/distancing/functions/check_end_exits.mcfunction
+++ b/data/distancing/functions/check_end_exits.mcfunction
@@ -9,5 +9,7 @@ setblock ~-1 64 0 bedrock
 setblock ~ 64 1 bedrock
 setblock ~ 64 -1 bedrock
 
-execute if entity @e[type=ender_dragon] run setblock ~ 64 0 air
-execute unless entity @e[type=ender_dragon] run setblock ~ 64 0 end_portal
+execute store success score $success dist_mem run clone -3 0 -3 3 255 3 -3 0 -3 filtered minecraft:end_portal move
+
+execute if score $success dist_mem matches 0 run setblock ~ 64 0 air
+execute unless score $success dist_mem matches 0 run setblock ~ 64 0 end_portal


### PR DESCRIPTION
Fixes #19 

The problem was, that the game does not spawn an ender dragon, if there is an end portal in the end, and the data pack sets an end portal in the first tick the end is loaded, before the game had a chance to summon the ender dragon

This approach checks for the main end portal being set, instead of checking for the ender dragon.
This also has the advantage, that during the resummoning sequence, when the ender dragon is not yet spawned, but the main end portal would usually be deactivated, all end portals are also deactivated.