### PR TITLE
Fix lag caused by constant spawn of aecs by using execute positioned

### DIFF
--- a/data/distancing/functions/find_fortress_1.mcfunction
+++ b/data/distancing/functions/find_fortress_1.mcfunction
@@ -1,0 +1,4 @@
+execute if score $fortress_copy dist_mem matches 2.. run scoreboard players remove $fortress_copy dist_mem 2
+
+execute if score $fortress_copy dist_mem matches 1.. positioned ~ ~ ~1 if block ~ 0 ~ bedrock run function distancing:place_fortress
+execute unless score $fortress_copy dist_mem matches 1.. if block ~ 0 ~ bedrock run function distancing:place_fortress

--- a/data/distancing/functions/find_fortress_128.mcfunction
+++ b/data/distancing/functions/find_fortress_128.mcfunction
@@ -1,0 +1,4 @@
+execute if score $fortress_copy dist_mem matches 256.. run scoreboard players remove $fortress_copy dist_mem 256
+
+execute unless score $fortress_copy dist_mem matches 128.. run function distancing:find_fortress_64
+execute if score $fortress_copy dist_mem matches 128.. positioned ~ ~ ~128 run function distancing:find_fortress_64

--- a/data/distancing/functions/find_fortress_16.mcfunction
+++ b/data/distancing/functions/find_fortress_16.mcfunction
@@ -1,0 +1,4 @@
+execute if score $fortress_copy dist_mem matches 32.. run scoreboard players remove $fortress_copy dist_mem 32
+
+execute unless score $fortress_copy dist_mem matches 16.. run function distancing:find_fortress_8
+execute if score $fortress_copy dist_mem matches 16.. positioned ~ ~ ~16 run function distancing:find_fortress_8

--- a/data/distancing/functions/find_fortress_2.mcfunction
+++ b/data/distancing/functions/find_fortress_2.mcfunction
@@ -1,0 +1,4 @@
+execute if score $fortress_copy dist_mem matches 4.. run scoreboard players remove $fortress_copy dist_mem 4
+
+execute unless score $fortress_copy dist_mem matches 2.. run function distancing:find_fortress_1
+execute if score $fortress_copy dist_mem matches 2.. positioned ~ ~ ~2 run function distancing:find_fortress_1

--- a/data/distancing/functions/find_fortress_256.mcfunction
+++ b/data/distancing/functions/find_fortress_256.mcfunction
@@ -1,0 +1,4 @@
+execute if score $fortress_copy dist_mem matches 512.. run scoreboard players remove $fortress_copy dist_mem 512
+
+execute unless score $fortress_copy dist_mem matches 256.. run function distancing:find_fortress_128
+execute if score $fortress_copy dist_mem matches 256.. positioned ~ ~ ~256 run function distancing:find_fortress_128

--- a/data/distancing/functions/find_fortress_32.mcfunction
+++ b/data/distancing/functions/find_fortress_32.mcfunction
@@ -1,0 +1,4 @@
+execute if score $fortress_copy dist_mem matches 64.. run scoreboard players remove $fortress_copy dist_mem 64
+
+execute unless score $fortress_copy dist_mem matches 32.. run function distancing:find_fortress_16
+execute if score $fortress_copy dist_mem matches 32.. positioned ~ ~ ~32 run function distancing:find_fortress_16

--- a/data/distancing/functions/find_fortress_4.mcfunction
+++ b/data/distancing/functions/find_fortress_4.mcfunction
@@ -1,0 +1,4 @@
+execute if score $fortress_copy dist_mem matches 8.. run scoreboard players remove $fortress_copy dist_mem 8
+
+execute unless score $fortress_copy dist_mem matches 4.. run function distancing:find_fortress_2
+execute if score $fortress_copy dist_mem matches 4.. positioned ~ ~ ~4 run function distancing:find_fortress_2

--- a/data/distancing/functions/find_fortress_512.mcfunction
+++ b/data/distancing/functions/find_fortress_512.mcfunction
@@ -1,0 +1,4 @@
+execute if score $fortress_copy dist_mem matches 1024.. run scoreboard players remove $fortress_copy dist_mem 1024
+
+execute unless score $fortress_copy dist_mem matches 512.. run function distancing:find_fortress_256
+execute if score $fortress_copy dist_mem matches 512.. positioned ~ ~ ~512 run function distancing:find_fortress_256

--- a/data/distancing/functions/find_fortress_64.mcfunction
+++ b/data/distancing/functions/find_fortress_64.mcfunction
@@ -1,0 +1,4 @@
+execute if score $fortress_copy dist_mem matches 128.. run scoreboard players remove $fortress_copy dist_mem 128
+
+execute unless score $fortress_copy dist_mem matches 64.. run function distancing:find_fortress_32
+execute if score $fortress_copy dist_mem matches 64.. positioned ~ ~ ~64 run function distancing:find_fortress_32

--- a/data/distancing/functions/find_fortress_8.mcfunction
+++ b/data/distancing/functions/find_fortress_8.mcfunction
@@ -1,0 +1,4 @@
+execute if score $fortress_copy dist_mem matches 16.. run scoreboard players remove $fortress_copy dist_mem 16
+
+execute unless score $fortress_copy dist_mem matches 8.. run function distancing:find_fortress_4
+execute if score $fortress_copy dist_mem matches 8.. positioned ~ ~ ~8 run function distancing:find_fortress_4

--- a/data/distancing/functions/find_fortress_negative.mcfunction
+++ b/data/distancing/functions/find_fortress_negative.mcfunction
@@ -1,0 +1,6 @@
+# If position is < 0, move start to lowest possible (-2047) and "bitwise invert" score
+
+scoreboard players add $fortress_copy dist_mem 2047
+
+execute unless score $fortress_copy dist_mem matches 1024.. positioned ~ ~ -2047 run function distancing:find_fortress_512
+execute if score $fortress_copy dist_mem matches 1024.. positioned ~ ~ -1023 run function distancing:find_fortress_512

--- a/data/distancing/functions/place_fortress.mcfunction
+++ b/data/distancing/functions/place_fortress.mcfunction
@@ -1,10 +1,7 @@
 # Place a fortress segment
 
-say running place_fortress
-
-forceload add ~-5 ~-2 ~5 ~2
-
 tag @s add dist_has_fortress
+summon area_effect_cloud ~ 60 ~ {Tags:["dist_fortress"], Age:-2147483648, Duration:-1, WaitTime:-2147483648}
 
 fill ~-5 10 ~-2 ~5 59 ~2 nether_bricks
 fill ~-5 60 ~-2 ~5 60 ~-2 nether_bricks

--- a/data/distancing/functions/spawn_fortress_mob.mcfunction
+++ b/data/distancing/functions/spawn_fortress_mob.mcfunction
@@ -1,7 +1,0 @@
-# Spawn a fortress mob at a fortress piece
-
-summon area_effect_cloud ~ 60 ~ {Tags:["dist_locator"],Duration:2}
-execute store result entity @e[type=area_effect_cloud,tag=dist_locator,limit=1] Pos[2] double 1 run scoreboard players get $fortress dist_mem
-execute at @e[type=area_effect_cloud,tag=dist_locator,limit=1] positioned ~ 60 ~ if entity @a[distance=..120,limit=1] unless entity @a[distance=..20,limit=1] run function distancing:spawn_random_fortress_mob
-tp @e[type=area_effect_cloud,tag=dist_locator,limit=1] ~ ~ ~
-kill @e[type=area_effect_cloud,tag=dist_locator,limit=1]

--- a/data/distancing/functions/tick.mcfunction
+++ b/data/distancing/functions/tick.mcfunction
@@ -13,7 +13,7 @@ execute as @a run scoreboard players operation @s dist_list = @s dist_x
 
 execute as @e[type=eye_of_ender] run function distancing:set_eye
 
-execute as @a[scores={dist_dimension=-1},tag=!dist_has_fortress] at @s run function distancing:try_place_fortress
+execute as @a[gamemode=!spectator,scores={dist_dimension=-1},tag=!dist_has_fortress] at @s run function distancing:try_place_fortress
 
 scoreboard players add $spawn_tick dist_mem 1
-execute if score $spawn_tick dist_mem matches 1200.. at @a[scores={dist_dimension=-1},sort=random,limit=1] run function distancing:spawn_fortress_mob
+execute if score $spawn_tick dist_mem matches 1200.. at @e[type=area_effect_cloud,tag=dist_fortress,sort=random,limit=1] if entity @a[gamemode=!spectator,distance=..120,limit=1] unless entity @a[gamemode=!spectator,distance=..20,limit=1] run function distancing:spawn_random_fortress_mob

--- a/data/distancing/functions/try_place_fortress.mcfunction
+++ b/data/distancing/functions/try_place_fortress.mcfunction
@@ -1,7 +1,6 @@
 # Find the fortress location and try to place a portal there
 
-summon area_effect_cloud ~ ~ ~ {Tags:["dist_locator"],Duration:2}
-execute store result entity @e[type=area_effect_cloud,tag=dist_locator,limit=1] Pos[2] double 1 run scoreboard players get $fortress dist_mem
-execute at @e[type=area_effect_cloud,tag=dist_locator,limit=1] run function distancing:place_fortress
-tp @e[type=area_effect_cloud,tag=dist_locator,limit=1] ~ ~ ~
-kill @e[type=area_effect_cloud,tag=dist_locator,limit=1]
+scoreboard players operation $fortress_copy dist_mem = $fortress dist_mem
+
+execute unless score $fortress_copy dist_mem matches 1024.. positioned ~ ~ 0 run function distancing:find_fortress_512
+execute if score $fortress_copy dist_mem matches 1024.. positioned ~ ~ 1024 run function distancing:find_fortress_512

--- a/data/distancing/functions/try_place_fortress.mcfunction
+++ b/data/distancing/functions/try_place_fortress.mcfunction
@@ -4,4 +4,4 @@ scoreboard players operation $fortress_copy dist_mem = $fortress dist_mem
 
 execute if score $fortress_copy dist_mem matches 0..1023 positioned ~ ~ 0 run function distancing:find_fortress_512
 execute if score $fortress_copy dist_mem matches 1024.. positioned ~ ~ 1024 run function distancing:find_fortress_512
-execute if score $fortress_copy dist_mem matches ..0 run function distancing:find_fortress_negative
+execute if score $fortress_copy dist_mem matches ..-1 run function distancing:find_fortress_negative

--- a/data/distancing/functions/try_place_fortress.mcfunction
+++ b/data/distancing/functions/try_place_fortress.mcfunction
@@ -2,5 +2,6 @@
 
 scoreboard players operation $fortress_copy dist_mem = $fortress dist_mem
 
-execute unless score $fortress_copy dist_mem matches 1024.. positioned ~ ~ 0 run function distancing:find_fortress_512
+execute if score $fortress_copy dist_mem matches 0..1023 positioned ~ ~ 0 run function distancing:find_fortress_512
 execute if score $fortress_copy dist_mem matches 1024.. positioned ~ ~ 1024 run function distancing:find_fortress_512
+execute if score $fortress_copy dist_mem matches ..0 run function distancing:find_fortress_negative


### PR DESCRIPTION
Fixes #23
This replaces the aec logic with a bunch of functions that all follow the same scheme of changing the location relatively in a binary pattern.

Also when working on this, I noticed spectators could cause fortresses to spawn, and also affect mob spawning in those fortresses. This is also fixed in this pr.